### PR TITLE
Move connects_to to abstract class

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,3 +1,5 @@
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
+
+  connects_to database: { writing: :primary, reading: :follower }
 end

--- a/app/models/my_model.rb
+++ b/app/models/my_model.rb
@@ -1,3 +1,2 @@
 class MyModel < ApplicationRecord
-  connects_to database: { writing: :primary, reading: :follower } 
 end


### PR DESCRIPTION
The `connects_to` for multi-db should be in an abstract class that
individual models inherit from in order to prevent duplicate
connections.